### PR TITLE
XcodeGenで生成した時にバージョンをMARKETING_VERSIONに設定する

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -21,6 +21,8 @@ targets:
         - xcodegenExampleTests
         - xcodegenExampleUITests
       gatherCoverageData: true
+    settings:
+      MARKETING_VERSION: 1.2.0 # 追加する
   xcodegenExampleTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 概要

XcodeGenで生成した時にバージョンをMARKETING_VERSIONに設定する

バージョンが入るようになる
![image](https://user-images.githubusercontent.com/3356758/71992605-fbc9eb80-3278-11ea-9f66-90f6070a9194.png)
